### PR TITLE
docs: Add communicaton to PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -9,4 +9,4 @@
 - [ ] Security design - OWASP Top 10 risks are mitigated
 
 # 💬 Other Requirements
-- [ ] Communication - Changes that will affect other teams have been communicated in slack
+- [ ] Communication - Changes that will affect other teams have been communicated in Slack

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,4 @@
-# Pending code review items
+# ⚙️ Technical Requirements
 
 - [ ] Clean code – well formatted code, proper indentation, only needed usings, general coding convention as described by Microsoft
 - [ ] Readable code – well written code barely requires inline comments. Proper naming, structure of code blocks, OOP principles, AOP principles, SOLID principles, etc.
@@ -7,3 +7,6 @@
 - [ ] API design – APIs are resource oriented, easy to read, proper HTTP verbs, correct status code results
 - [ ] API documentation - public endpoints are documented in Swagger, non-public ones are hidden from Swagger
 - [ ] Security design - OWASP Top 10 risks are mitigated
+
+# 💬 Other Requirements
+- [ ] Communication - Changes that will affect other teams have been communicated in slack


### PR DESCRIPTION
Add a reminder to communicate large changes to PR descriptions. Intended to help mitigate ongoing communication issues with changes that affect other teams (large changes affecting QA, colocated code affecting Sofia etc.) 

Related issues have been raised at several retros now.
